### PR TITLE
refactor: Inclui itens obrigatórios da declaração de conteudo

### DIFF
--- a/src/main/java/io/t3w/correios/prepostagem/T3WCorreiosPrepostagemItemDeclaracaoConteudo.java
+++ b/src/main/java/io/t3w/correios/prepostagem/T3WCorreiosPrepostagemItemDeclaracaoConteudo.java
@@ -43,12 +43,12 @@ public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
      * Peso total dos itens, em gramas.
      */
     @JsonProperty("peso")
-    private BigDecimal peso;
+    private int peso;
 
     public T3WCorreiosPrepostagemItemDeclaracaoConteudo() {
     }
 
-    public T3WCorreiosPrepostagemItemDeclaracaoConteudo(String conteudo, int quantidade, BigDecimal valor, BigDecimal peso) {
+    public T3WCorreiosPrepostagemItemDeclaracaoConteudo(String conteudo, int quantidade, BigDecimal valor, int peso) {
         this.conteudo = conteudo;
         this.quantidade = quantidade;
         this.valor = valor;
@@ -82,11 +82,11 @@ public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
         return this;
     }
 
-    public BigDecimal getPeso() {
+    public int getPeso() {
         return peso;
     }
 
-    public T3WCorreiosPrepostagemItemDeclaracaoConteudo setPeso(BigDecimal peso) {
+    public T3WCorreiosPrepostagemItemDeclaracaoConteudo setPeso(int peso) {
         this.peso = peso;
         return this;
     }

--- a/src/main/java/io/t3w/correios/prepostagem/T3WCorreiosPrepostagemItemDeclaracaoConteudo.java
+++ b/src/main/java/io/t3w/correios/prepostagem/T3WCorreiosPrepostagemItemDeclaracaoConteudo.java
@@ -3,6 +3,8 @@ package io.t3w.correios.prepostagem;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.math.BigDecimal;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 
 public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
@@ -10,15 +12,15 @@ public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
     private String conteudo;
 
     @JsonProperty("quantidade")
-    private String quantidade;
+    private int quantidade;
 
     @JsonProperty("valor")
-    private String valor;
+    private BigDecimal valor;
 
     public T3WCorreiosPrepostagemItemDeclaracaoConteudo() {
     }
 
-    public T3WCorreiosPrepostagemItemDeclaracaoConteudo(String conteudo, String quantidade, String valor) {
+    public T3WCorreiosPrepostagemItemDeclaracaoConteudo(String conteudo, int quantidade, BigDecimal valor) {
         this.conteudo = conteudo;
         this.quantidade = quantidade;
         this.valor = valor;
@@ -33,20 +35,20 @@ public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
         return this;
     }
 
-    public String getQuantidade() {
+    public int getQuantidade() {
         return quantidade;
     }
 
-    public T3WCorreiosPrepostagemItemDeclaracaoConteudo setQuantidade(String quantidade) {
+    public T3WCorreiosPrepostagemItemDeclaracaoConteudo setQuantidade(int quantidade) {
         this.quantidade = quantidade;
         return this;
     }
 
-    public String getValor() {
+    public BigDecimal getValor() {
         return valor;
     }
 
-    public T3WCorreiosPrepostagemItemDeclaracaoConteudo setValor(String valor) {
+    public T3WCorreiosPrepostagemItemDeclaracaoConteudo setValor(BigDecimal valor) {
         this.valor = valor;
         return this;
     }

--- a/src/main/java/io/t3w/correios/prepostagem/T3WCorreiosPrepostagemItemDeclaracaoConteudo.java
+++ b/src/main/java/io/t3w/correios/prepostagem/T3WCorreiosPrepostagemItemDeclaracaoConteudo.java
@@ -5,25 +5,54 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
 
+/**
+ * Representa um item da declaração de conteúdo exigida na pré-postagem dos Correios.
+ *
+ * <p><strong>IMPORTANTE:</strong> A partir de 2025, os Correios exigem que cada pré-postagem
+ * informe obrigatoriamente um dos seguintes:
+ * <ol>
+ *   <li>Chave da nota fiscal (NF-e)</li>
+ *   <li>Chave da declaração de conteúdo eletrônica</li>
+ *   <li>Ou os <strong>itens detalhados</strong> da declaração de conteúdo: {@code conteudo}, {@code quantidade}, {@code valor} e {@code peso}</li>
+ * </ol>
+ *
+ * <p>Esta classe representa a terceira opção: o detalhamento dos itens da declaração de conteúdo.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
-
 public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
+
+    /**
+     * Descrição do conteúdo enviado (ex: "Materiais promocionais", "HDs").
+     */
     @JsonProperty("conteudo")
     private String conteudo;
 
+    /**
+     * Quantidade de unidades do item.
+     */
     @JsonProperty("quantidade")
     private int quantidade;
 
+    /**
+     * Valor total dos itens.
+     */
     @JsonProperty("valor")
     private BigDecimal valor;
+
+    /**
+     * Peso total dos itens, em gramas.
+     */
+    @JsonProperty("peso")
+    private BigDecimal peso;
 
     public T3WCorreiosPrepostagemItemDeclaracaoConteudo() {
     }
 
-    public T3WCorreiosPrepostagemItemDeclaracaoConteudo(String conteudo, int quantidade, BigDecimal valor) {
+    public T3WCorreiosPrepostagemItemDeclaracaoConteudo(String conteudo, int quantidade, BigDecimal valor, BigDecimal peso) {
         this.conteudo = conteudo;
         this.quantidade = quantidade;
         this.valor = valor;
+        this.peso = peso;
     }
 
     public String getConteudo() {
@@ -50,6 +79,15 @@ public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
 
     public T3WCorreiosPrepostagemItemDeclaracaoConteudo setValor(BigDecimal valor) {
         this.valor = valor;
+        return this;
+    }
+
+    public BigDecimal getPeso() {
+        return peso;
+    }
+
+    public T3WCorreiosPrepostagemItemDeclaracaoConteudo setPeso(BigDecimal peso) {
+        this.peso = peso;
         return this;
     }
 }

--- a/src/test/java/io/t3w/correios/T3WCorreiosTest.java
+++ b/src/test/java/io/t3w/correios/T3WCorreiosTest.java
@@ -130,7 +130,7 @@ class T3WCorreiosTest {
 
         // Itens da declaração de conteúdo, passou a ser obrigatório o envio, conforme resposta da API do Correios
         // "NF e declaração de conteúdo: Obrigatório informar a chave da nota fiscal, chave da declaração de conteúdo eletrônica ou os itens da declaração de conteúdo."
-        prepostagem.setItensDeclaracaoConteudo(List.of(new T3WCorreiosPrepostagemItemDeclaracaoConteudo("Teste", 1, BigDecimal.valueOf(10), BigDecimal.valueOf(600))));
+        prepostagem.setItensDeclaracaoConteudo(List.of(new T3WCorreiosPrepostagemItemDeclaracaoConteudo("Teste", 1, BigDecimal.valueOf(10), 600)));
         final T3WCorreiosPrepostagem prepostagemEfetivada = CORREIOS.criarPrepostagem(prepostagem);
     }
 

--- a/src/test/java/io/t3w/correios/T3WCorreiosTest.java
+++ b/src/test/java/io/t3w/correios/T3WCorreiosTest.java
@@ -45,7 +45,7 @@ class T3WCorreiosTest {
         CNPJ = System.getenv("CORREIOS_CNPJ");
         CONTRATO = System.getenv("CORREIOS_CONTRATO");
         DRSE_CONTRATO = System.getenv("CORREIOS_DRSE_CONTRATO");
-        CORREIOS = new T3WCorreios(USER_ID, API_TOKEN, CARTAO_POSTAGEM, true);
+        CORREIOS = new T3WCorreios(USER_ID, API_TOKEN, CARTAO_POSTAGEM, false);
     }
 
     @Disabled
@@ -130,7 +130,7 @@ class T3WCorreiosTest {
 
         // Itens da declaração de conteúdo, passou a ser obrigatório o envio, conforme resposta da API do Correios
         // "NF e declaração de conteúdo: Obrigatório informar a chave da nota fiscal, chave da declaração de conteúdo eletrônica ou os itens da declaração de conteúdo."
-        prepostagem.setItensDeclaracaoConteudo(List.of(new T3WCorreiosPrepostagemItemDeclaracaoConteudo("Teste", 1, BigDecimal.valueOf(10))));
+        prepostagem.setItensDeclaracaoConteudo(List.of(new T3WCorreiosPrepostagemItemDeclaracaoConteudo("Teste", 1, BigDecimal.valueOf(10), BigDecimal.valueOf(600))));
         final T3WCorreiosPrepostagem prepostagemEfetivada = CORREIOS.criarPrepostagem(prepostagem);
     }
 

--- a/src/test/java/io/t3w/correios/T3WCorreiosTest.java
+++ b/src/test/java/io/t3w/correios/T3WCorreiosTest.java
@@ -45,7 +45,7 @@ class T3WCorreiosTest {
         CNPJ = System.getenv("CORREIOS_CNPJ");
         CONTRATO = System.getenv("CORREIOS_CONTRATO");
         DRSE_CONTRATO = System.getenv("CORREIOS_DRSE_CONTRATO");
-        CORREIOS = new T3WCorreios(USER_ID, API_TOKEN, CARTAO_POSTAGEM, false);
+        CORREIOS = new T3WCorreios(USER_ID, API_TOKEN, CARTAO_POSTAGEM, true);
     }
 
     @Disabled

--- a/src/test/java/io/t3w/correios/T3WCorreiosTest.java
+++ b/src/test/java/io/t3w/correios/T3WCorreiosTest.java
@@ -6,6 +6,7 @@ import io.t3w.correios.contratos.enums.T3WCorreiosContratoStatus;
 import io.t3w.correios.faturas.T3WCorreiosFatura;
 import io.t3w.correios.faturas.T3WCorreiosFaturaProcessoAssincrono;
 import io.t3w.correios.faturas.enums.T3WCorreiosFaturasTipoPrevia;
+import io.t3w.correios.prepostagem.T3WCorreiosPrepostagemItemDeclaracaoConteudo;
 import io.t3w.correios.prepostagem.T3WCorreiosPrepostagemRequisicaoRotulo;
 import io.t3w.correios.responses.T3WCorreiosResponseDefault;
 import io.t3w.correios.preco.enums.T3WCorreiosPrecoServicoAdicional;
@@ -126,6 +127,10 @@ class T3WCorreiosTest {
         final var remetente = new T3WCorreiosPessoa("teste", new T3WCorreiosEndereco("88101000", "Av. Presidente Kennedy", "568", "CAMPINAS", "SAO JOSE", "SC")).setCpfCnpj(CNPJ);
         final var destinatario = new T3WCorreiosPessoa("teste", new T3WCorreiosEndereco("88101000", "Av. Presidente Kennedy", "568", "CAMPINAS", "SAO JOSE", "SC"));
         final var prepostagem = new T3WCorreiosPrepostagem(remetente, destinatario, "03220", "30", "1", "1");
+
+        // Itens da declaração de conteúdo, passou a ser obrigatório o envio, conforme resposta da API do Correios
+        // "NF e declaração de conteúdo: Obrigatório informar a chave da nota fiscal, chave da declaração de conteúdo eletrônica ou os itens da declaração de conteúdo."
+        prepostagem.setItensDeclaracaoConteudo(List.of(new T3WCorreiosPrepostagemItemDeclaracaoConteudo("Teste", 1, BigDecimal.valueOf(10))));
         final T3WCorreiosPrepostagem prepostagemEfetivada = CORREIOS.criarPrepostagem(prepostagem);
     }
 


### PR DESCRIPTION
- Torna obrigatório o campo `itensDeclaracaoConteudo` nos testes de pré-postagem, conforme nova exigência da API dos Correios (chave NF, chave da declaração ou itens obrigatórios).
- Corrige tipos em `T3WCorreiosPrepostagemItemDeclaracaoConteudo`: `quantidade` como `int` e `valor` como `BigDecimal`.
