### PR TITLE
Normaliza valor do item declaração de conteúdo, tratamento de erro fora do padrão de retorno da API

### DIFF
--- a/src/main/java/io/t3w/correios/prepostagem/T3WCorreiosPrepostagemItemDeclaracaoConteudo.java
+++ b/src/main/java/io/t3w/correios/prepostagem/T3WCorreiosPrepostagemItemDeclaracaoConteudo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 /**
  * Representa um item da declaração de conteúdo exigida na pré-postagem dos Correios.
@@ -51,7 +52,7 @@ public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
     public T3WCorreiosPrepostagemItemDeclaracaoConteudo(String conteudo, int quantidade, BigDecimal valor, int peso) {
         this.conteudo = conteudo;
         this.quantidade = quantidade;
-        this.valor = valor;
+        this.valor = normalizarValor(valor);
         this.peso = peso;
     }
 
@@ -78,7 +79,7 @@ public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
     }
 
     public T3WCorreiosPrepostagemItemDeclaracaoConteudo setValor(BigDecimal valor) {
-        this.valor = valor;
+        this.valor = normalizarValor(valor);
         return this;
     }
 
@@ -89,5 +90,9 @@ public class T3WCorreiosPrepostagemItemDeclaracaoConteudo {
     public T3WCorreiosPrepostagemItemDeclaracaoConteudo setPeso(int peso) {
         this.peso = peso;
         return this;
+    }
+
+    private static BigDecimal normalizarValor(BigDecimal valor) {
+        return valor != null ? valor.setScale(2, RoundingMode.HALF_UP) : BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/io/t3w/correios/responses/T3WCorreiosResponseDefault.java
+++ b/src/main/java/io/t3w/correios/responses/T3WCorreiosResponseDefault.java
@@ -2,6 +2,7 @@ package io.t3w.correios.responses;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
 
 import java.time.LocalDateTime;
 
@@ -44,5 +45,27 @@ public class T3WCorreiosResponseDefault extends Throwable {
 
     public String[] getMsgs() {
         return msgs;
+    }
+
+    @JsonSetter("msgs")
+    public T3WCorreiosResponseDefault setMsgs(String[] msgs) {
+        this.msgs = msgs;
+        return this;
+    }
+
+    // Coisas da api dos correios... Acusa que erros 400 deveriam vir no padrão do objeto, mas em alguns casos retorna body com { "msg": "texto" }
+    @JsonSetter("msg")
+    public T3WCorreiosResponseDefault setMsg(String msg) {
+        if (msg != null) {
+            if (this.msgs == null) {
+                this.msgs = new String[]{msg};
+            } else {
+                String[] newMsgs = new String[this.msgs.length + 1];
+                System.arraycopy(this.msgs, 0, newMsgs, 0, this.msgs.length);
+                newMsgs[this.msgs.length] = msg;
+                this.msgs = newMsgs;
+            }
+        }
+        return this;
     }
 }


### PR DESCRIPTION
Normaliza valor do item para declaração de conteúdo
Adiciona tratamento para retorno de erro somente com um campo 'msg' único, diferente do padrão da documentação.